### PR TITLE
Example with Django admin's default modelform.

### DIFF
--- a/autocomplete_light/example_apps/modelform_admin_issue/admin.py
+++ b/autocomplete_light/example_apps/modelform_admin_issue/admin.py
@@ -9,7 +9,6 @@ from .models import XModel, YModel, ZModel
 
 
 class YModelForm(forms.ModelForm):
-    x = autocomplete_light.ModelChoiceField('XModelAutocomplete', label="XModel")
 
     class Meta:
         exclude = tuple()


### PR DESCRIPTION
As you can see, Django will make the automatic formfield for YModel.x as
a **required** select. Hence the `ValidationError`.